### PR TITLE
Email confirmation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,8 +37,10 @@ group :test, :development do
   gem 'capybara-webkit'
   gem 'selenium-webdriver'
   gem 'database_cleaner'
+  gem 'letter_opener'
 end
 
 group :test do
   gem 'shoulda-matchers'
+  gem 'capybara-email'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -35,6 +35,7 @@ group :test, :development do
   gem 'capybara'
   gem 'launchy'
   gem 'capybara-webkit'
+  gem 'selenium-webdriver'
   gem 'database_cleaner'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -68,6 +68,8 @@ GEM
       json (>= 1.7)
       mime-types (>= 1.16)
       mimemagic (>= 0.3.0)
+    childprocess (0.5.9)
+      ffi (~> 1.0, >= 1.0.11)
     cocoon (1.2.9)
     coffee-rails (4.1.1)
       coffee-script (>= 2.2.0)
@@ -117,6 +119,7 @@ GEM
     faye-websocket (0.10.4)
       eventmachine (>= 0.12.0)
       websocket-driver (>= 0.5.1)
+    ffi (1.9.10)
     globalid (0.3.6)
       activesupport (>= 4.1.0)
     hashie (3.4.4)
@@ -245,6 +248,7 @@ GEM
       ruby-progressbar (~> 1.7)
       unicode-display_width (~> 1.0, >= 1.0.1)
     ruby-progressbar (1.8.1)
+    rubyzip (1.2.0)
     sass (3.4.22)
     sass-rails (5.0.4)
       railties (>= 4.0.0, < 5.0)
@@ -255,6 +259,10 @@ GEM
     sdoc (0.4.1)
       json (~> 1.7, >= 1.7.7)
       rdoc (~> 4.0)
+    selenium-webdriver (2.53.0)
+      childprocess (~> 0.5)
+      rubyzip (~> 1.0)
+      websocket (~> 1.0)
     shoulda-matchers (3.1.1)
       activesupport (>= 4.0.0)
     skim (0.10.0)
@@ -295,6 +303,7 @@ GEM
     unicode-display_width (1.0.5)
     warden (1.2.6)
       rack (>= 1.0)
+    websocket (1.2.3)
     websocket-driver (0.6.4)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.2)
@@ -330,6 +339,7 @@ DEPENDENCIES
   rubocop
   sass-rails
   sdoc
+  selenium-webdriver
   shoulda-matchers
   skim
   slim-rails

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -59,6 +59,9 @@ GEM
       rack (>= 1.0.0)
       rack-test (>= 0.5.4)
       xpath (~> 2.0)
+    capybara-email (2.5.0)
+      capybara (~> 2.4)
+      mail
     capybara-webkit (1.11.1)
       capybara (>= 2.3.0, < 2.8.0)
       json
@@ -143,6 +146,8 @@ GEM
       less (~> 2.6.0)
       sprockets (> 2, < 4)
       tilt
+    letter_opener (1.4.1)
+      launchy (~> 2.2)
     loofah (2.0.3)
       nokogiri (>= 1.5.9)
     mail (2.6.4)
@@ -316,6 +321,7 @@ PLATFORMS
 DEPENDENCIES
   cancancan
   capybara
+  capybara-email
   capybara-webkit
   carrierwave
   cocoon
@@ -326,6 +332,7 @@ DEPENDENCIES
   jbuilder
   jquery-rails
   launchy
+  letter_opener
   omniauth
   omniauth-facebook
   omniauth-twitter

--- a/app/assets/javascripts/comments.coffee
+++ b/app/assets/javascripts/comments.coffee
@@ -5,7 +5,7 @@ ready = ->
     commentable_id = $.parseJSON(data['comment']).commentable_id
     commentable_type = $.parseJSON(data['comment']).commentable_type
 
-    $( '.' + commentable_type + '-comments#' + commentable_id).append(
+    $( '.' + commentable_type + '-comments#c_' + commentable_id).append(
       JST["templates/comment"]({comment_author: comment_author, comment: comment_body})
     )
     $('textarea#comment_body').val('')

--- a/app/controllers/authorizations_controller.rb
+++ b/app/controllers/authorizations_controller.rb
@@ -8,14 +8,51 @@ class AuthorizationsController < ApplicationController
     provider = session['devise.oauth_data']['provider']
     uid = session['devise.oauth_data']['uid']
     email = params[:email]
-    auth = OmniAuth::AuthHash.new({ provider: provider, uid: uid, info: {email: email} })
-    @user = User.find_for_oauth(auth) unless email.blank?
-    if @user && @user.persisted?
-      sign_in_and_redirect @user, event: :authentication
-      flash[:notice] = "Successfully authenticated from #{provider.to_s} account."
+    auth_hash = OmniAuth::AuthHash.new({ provider: provider, uid: uid, info: {email: email} })
+
+    @user = User.find_for_oauth(auth_hash) unless email.blank?
+    @auth = @user.authorizations.find_by(provider: provider)
+    authenticate_if_confirmed(@auth)
+  end
+
+  def confirm_auth
+    @auth = Authorization.find_by(token: (params[:token]))
+    confirm_authorization(@auth)
+  end
+
+  def resend_confirmation_email
+    user = User.find(session["devise.user"]["user_id"])
+    ConfirmOauth.email_confirmation(user).deliver_now
+    email_sent_message
+  end
+
+  private
+
+  def confirm_authorization(auth)
+    if auth
+      auth.confirm!
+      log_in(auth)
     else
       redirect_to new_user_registration_path
-      flash[:notice] = "Could not authenticate you from #{provider.to_s} account."
+      flash[:notice] = "Failed. Invalid Authorization token"
     end
+  end
+
+  def authenticate_if_confirmed(auth)
+    if auth.confirmed?
+      log_in(auth)
+    else
+      email_sent_message
+    end
+  end
+
+  def email_sent_message
+    redirect_to new_user_registration_path
+    flash[:notice] = "Email sent. Please confirm your authorization."
+  end
+
+  def log_in(auth)
+    sign_in_and_redirect auth.user, event: :authentication
+    flash[:notice] = "Successfully authenticated from #{auth.provider.to_s} account."
   end
 end

--- a/app/controllers/omniauth_callbacks_controller.rb
+++ b/app/controllers/omniauth_callbacks_controller.rb
@@ -23,7 +23,7 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
       auth = @user.authorizations.find_by(provider: provider)
       check_authorization(auth)
     else
-      session["devise.oauth_data"] = {provider: auth_hash.provider, uid: auth_hash.uid}
+      session["devise.oauth_data"] = { provider: auth_hash.provider, uid: auth_hash.uid }
       redirect_to new_authorization_path
     end
   end

--- a/app/controllers/omniauth_callbacks_controller.rb
+++ b/app/controllers/omniauth_callbacks_controller.rb
@@ -15,15 +15,27 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
   private
 
   def oauth
-    auth = request.env['omniauth.auth']
+    auth_hash = request.env['omniauth.auth']
     provider = request.env['omniauth.auth'][:provider].to_s
-    @user = User.find_for_oauth(auth)
+    @user = User.find_for_oauth(auth_hash)
+
     if @user.persisted?
-      sign_in_and_redirect @user, event: :authentication
-      set_flash_message(:notice, :success, kind: provider) if is_navigational_format?
+      auth = @user.authorizations.find_by(provider: provider)
+      check_authorization(auth)
     else
-      session["devise.oauth_data"] = {provider: auth.provider, uid: auth.uid}
+      session["devise.oauth_data"] = {provider: auth_hash.provider, uid: auth_hash.uid}
       redirect_to new_authorization_path
+    end
+  end
+
+  def check_authorization(auth)
+    if auth.confirmed?
+      sign_in_and_redirect auth.user, event: :authentication
+      set_flash_message(:notice, :success, kind: auth.provider) if is_navigational_format?
+    else
+      redirect_to new_user_registration_path
+      flash[:notice] = "Please confirm your authorization by email."
+      session["devise.user"] = {user_id: auth.user_id}
     end
   end
 end

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,0 +1,3 @@
+class ApplicationMailer < ActionMailer::Base
+  default from: "main@stackapp.com"
+end

--- a/app/mailers/confirm_oauth.rb
+++ b/app/mailers/confirm_oauth.rb
@@ -1,0 +1,10 @@
+class ConfirmOauth < ApplicationMailer
+  default from: "security@stackapp.com"
+
+  def email_confirmation(user)
+    @user = user
+    auth = @user.authorizations.last
+    @url = confirm_auth_url(token: auth.token)
+    mail(to: @user.email, subject: 'StackApp. Please confirm authorization')
+  end
+end

--- a/app/models/authorization.rb
+++ b/app/models/authorization.rb
@@ -2,4 +2,8 @@ class Authorization < ActiveRecord::Base
   belongs_to :user
 
   validates :provider, :uid, presence: true
+
+  def confirm!
+    self.update(confirmed: true)
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -27,16 +27,18 @@ class User < ActiveRecord::Base
     end
 
     if user
-      user.create_auth(auth)
+      user.create_auth(auth, false)
+      ConfirmOauth.email_confirmation(user).deliver_now
     else
       password = Devise.friendly_token[0, 20]
       user = User.create!(email: email, password: password, password_confirmation: password)
-      user.create_auth(auth)
+      user.create_auth(auth, true)
     end
     user
   end
 
-  def create_auth(auth)
-    authorizations.create(provider: auth.provider, uid: auth.uid)
+  def create_auth(auth, conf)
+    token = Devise.friendly_token[0, 20]
+    authorizations.create(provider: auth.provider, uid: auth.uid, token: token, confirmed: conf)
   end
 end

--- a/app/views/confirm_oauth/email_confirmation.html.slim
+++ b/app/views/confirm_oauth/email_confirmation.html.slim
@@ -1,0 +1,4 @@
+h2 Hello, User!
+p You tried to add social network authorization.
+  Please confirm it:
+a href = @url confirm

--- a/app/views/devise/shared/_links.html.erb
+++ b/app/views/devise/shared/_links.html.erb
@@ -23,3 +23,7 @@
     <%= link_to "Sign in with #{OmniAuth::Utils.camelize(provider)}", omniauth_authorize_path(resource_name, provider) %><br />
   <% end -%>
 <% end -%>
+
+<%- if session["devise.user"] %>
+    <%= link_to "Resend confirmation?", resend_confirmation_email_path %><br />
+<% end -%>

--- a/app/views/questions/show.html.slim
+++ b/app/views/questions/show.html.slim
@@ -6,7 +6,7 @@ button.btn.btn-default.collapsed data-target="#q_comm_show" data-toggle="collaps
 .collapse id="q_comm_show"
 
   .comments
-    .Question-comments id="#{@question.id}"
+    .Question-comments id="c_#{@question.id}"
       h3 Comments:
       = render @question.comments.order('created_at')
     .question-comment-form
@@ -24,7 +24,7 @@ button.btn.btn-default.collapsed data-target="#q_comm_show" data-toggle="collaps
     .collapse id="a_comm_show#{answer.id}"
 
       .comments
-        .Answer-comments id="#{answer.id}"
+        .Answer-comments id="c_#{answer.id}"
           h4 Comments:
           = render answer.comments.order('created_at')
         .answer-comment-form

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -40,4 +40,5 @@ Rails.application.configure do
   # config.action_view.raise_on_missing_translations = true
 
   config.action_mailer.default_url_options = { host: 'localhost', port: 3000 }
+  config.action_mailer.delivery_method = :letter_opener
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -76,4 +76,6 @@ Rails.application.configure do
 
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
+
+  config.action_mailer.default_url_options = { host: 'www.stackapp.com' }
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -39,4 +39,7 @@ Rails.application.configure do
 
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
+
+  config.action_mailer.default_url_options = { host: 'localhost', port: 3000 }
+
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,6 +10,9 @@ Rails.application.routes.draw do
   end
 
   resources :authorizations, only: [:new, :create]
+  get 'confirm_auth', controller: :authorizations
+  get 'resend_confirmation_email', controller: :authorizations
+
 
   resources :questions, concerns: :votable do
     resources :comments, only: :create, defaults: {commentable: 'questions'}

--- a/db/migrate/20160602121651_add_token_and_confirmed_to_authorizations.rb
+++ b/db/migrate/20160602121651_add_token_and_confirmed_to_authorizations.rb
@@ -1,0 +1,7 @@
+class AddTokenAndConfirmedToAuthorizations < ActiveRecord::Migration
+  def change
+    add_column :authorizations, :token, :string
+    add_column :authorizations, :confirmed, :boolean, default: false
+    add_index :authorizations, :token
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160601090439) do
+ActiveRecord::Schema.define(version: 20160602121651) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -42,11 +42,14 @@ ActiveRecord::Schema.define(version: 20160601090439) do
     t.integer  "user_id"
     t.string   "provider"
     t.string   "uid"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at",                 null: false
+    t.datetime "updated_at",                 null: false
+    t.string   "token"
+    t.boolean  "confirmed",  default: false
   end
 
   add_index "authorizations", ["provider", "uid"], name: "index_authorizations_on_provider_and_uid", using: :btree
+  add_index "authorizations", ["token"], name: "index_authorizations_on_token", using: :btree
   add_index "authorizations", ["user_id"], name: "index_authorizations_on_user_id", using: :btree
 
   create_table "comments", force: :cascade do |t|

--- a/spec/acceptance/add_comment_to_answer_spec.rb
+++ b/spec/acceptance/add_comment_to_answer_spec.rb
@@ -8,7 +8,6 @@ feature 'Add comment' do
   scenario 'Authenticated user comments answer', js: true do
     log_in(user)
     visit question_path(question)
-    visit question_path(question)
 
     within '.answers' do
       click_on 'comments'

--- a/spec/acceptance/omniauth_authorization_spec.rb
+++ b/spec/acceptance/omniauth_authorization_spec.rb
@@ -18,16 +18,30 @@ feature 'Omniauth' do
       mock_auth_hash(info: {email: user.email})
       click_on 'Sign in with Facebook'
 
+      expect(page).to have_content 'Please confirm your authorization by email.'
+
+      open_email(user.email)
+      current_email.click_on 'confirm'
+
       expect(page).to have_content 'Successfully authenticated from facebook account.'
     end
 
-    it 'login user with existing authorization' do
-      user.authorizations.create(provider: 'facebook', uid: '123456')
+    it 'login user with confirmed authorization' do
+      user.authorizations.create(provider: 'facebook', uid: '123456', confirmed: true)
       visit new_user_registration_path
       mock_auth_hash(info: {email: user.email})
       click_on 'Sign in with Facebook'
 
       expect(page).to have_content 'Successfully authenticated from facebook account.'
+    end
+
+    it 'dont login user with unconfirmed authorization' do
+      user.authorizations.create(provider: 'facebook', uid: '123456', confirmed: false)
+      visit new_user_registration_path
+      mock_auth_hash(info: {email: user.email})
+      click_on 'Sign in with Facebook'
+
+      expect(page).to have_content 'Please confirm your authorization by email.'
     end
 
     it 'handle authentication error' do
@@ -54,16 +68,30 @@ feature 'Omniauth' do
       mock_auth_hash(provider: 'vkontakte', info: {email: user.email})
       click_on 'Sign in with Vkontakte'
 
+      expect(page).to have_content 'Please confirm your authorization by email.'
+
+      open_email(user.email)
+      current_email.click_on 'confirm'
+
       expect(page).to have_content 'Successfully authenticated from vkontakte account.'
     end
 
-    it 'login user with existing authorization' do
-      user.authorizations.create(provider: 'vkontakte', uid: '123456')
+    it 'login user with confirmed authorization' do
+      user.authorizations.create(provider: 'vkontakte', uid: '123456', confirmed: true)
       visit new_user_registration_path
       mock_auth_hash(provider: 'vkontakte', info: {email: user.email})
       click_on 'Sign in with Vkontakte'
 
       expect(page).to have_content 'Successfully authenticated from vkontakte account.'
+    end
+
+    it 'dont login user with unconfirmed authorization' do
+      user.authorizations.create(provider: 'vkontakte', uid: '123456', confirmed: false)
+      visit new_user_registration_path
+      mock_auth_hash(provider: 'vkontakte', info: {email: user.email})
+      click_on 'Sign in with Vkontakte'
+
+      expect(page).to have_content 'Please confirm your authorization by email.'
     end
 
     it 'handle authentication error' do
@@ -96,16 +124,30 @@ feature 'Omniauth' do
       fill_in 'Email:', with: user.email
       click_on 'Submit'
 
+      expect(page).to have_content 'Email sent. Please confirm your authorization.'
+
+      open_email(user.email)
+      current_email.click_on 'confirm'
+
       expect(page).to have_content 'Successfully authenticated from twitter account.'
     end
 
-    it 'login user with existing authorization' do
-      user.authorizations.create(provider: 'twitter', uid: '123456')
+    it 'login user with confirmed authorization' do
+      user.authorizations.create(provider: 'twitter', uid: '123456', confirmed: true)
       visit new_user_registration_path
       mock_auth_hash(provider: 'twitter', info: nil)
       click_on 'Sign in with Twitter'
 
       expect(page).to have_content 'Successfully authenticated from twitter account.'
+    end
+
+    it 'dont login user with unconfirmed authorization' do
+      user.authorizations.create(provider: 'twitter', uid: '123456', confirmed: false)
+      visit new_user_registration_path
+      mock_auth_hash(provider: 'twitter', info: nil)
+      click_on 'Sign in with Twitter'
+
+      expect(page).to have_content 'Please confirm your authorization by email.'
     end
 
     it 'handle authentication error' do
@@ -117,4 +159,18 @@ feature 'Omniauth' do
     end
   end
 
+  describe 'resend confirmation email' do
+    it 'sends again email' do
+      user.authorizations.create(provider: 'twitter', uid: '123456', token: 'newtoken', confirmed: false)
+      visit new_user_registration_path
+      mock_auth_hash(provider: 'twitter', info: nil)
+      click_on 'Sign in with Twitter'
+      click_on 'Resend confirmation?'
+
+      expect(page).to have_content 'Email sent. Please confirm your authorization.'
+      open_email(user.email)
+      current_email.click_on 'confirm'
+      expect(page).to have_content 'Successfully authenticated from twitter account.'
+    end
+  end
 end

--- a/spec/controllers/authorizations_controller_spec.rb
+++ b/spec/controllers/authorizations_controller_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe AuthorizationsController, type: :controller do
 
-  describe 'get #new' do
+  describe 'GET #new' do
     before do
       session['devise.oauth_data'] = {provider: 'twitter', uid: '123456'}
       get :new
@@ -11,25 +11,68 @@ RSpec.describe AuthorizationsController, type: :controller do
     it { should render_template :new }
   end
 
-  describe 'post #create' do
+  describe 'POST #create' do
     before do
       session['devise.oauth_data'] = {provider: 'twitter', uid: '123456'}
     end
-    context 'with valid data' do
-      it 'assigns user to User' do
-        post :create, email: 'user@email.com'
-        expect(assigns(:user)).to be_a(User)
+
+    context 'with existing user' do
+      let(:user){ create(:user) }
+
+      it 'assigns user to @user' do
+        post :create, email: user.email
+        expect(assigns(:user)).to eq user
       end
 
-      it 'redirects to root_path' do
-        post :create, email: 'user@email.com'
-        expect(response).to redirect_to root_path
+      it 'assigns authorization to @auth' do
+        post :create, email: user.email
+        expect(assigns(:auth)).to be_a(Auth)
       end
     end
 
     it 'redirects to authorization page if user not present' do
       post :create, email: nil
       expect(response).to redirect_to new_user_registration_path
+    end
+  end
+
+  describe 'GET #confirm_auth' do
+    let(:user){ create(:user) }
+    let!(:auth){ create(:authorization, user: user, token: '1234567890') }
+
+    context 'with valid token' do
+      before do
+        get :confirm_auth, token: '1234567890'
+      end
+
+      it 'assigns auth to @auth' do
+        expect(assigns(:auth)).to eq auth
+      end
+
+      it 'confirms authorization' do
+        auth.reload
+        expect(auth.confirmed).to be true
+      end
+
+      it 'redirects to root path' do
+        expect(response).to redirect_to root_path
+      end
+
+      it { should be_user_signed_in }
+    end
+
+    context 'with invalid token' do
+      before do
+        get :confirm_auth, token: '543210'
+      end
+
+      it 'dont confirms authorization' do
+        expect(auth.confirmed).to be false
+      end
+
+      it 'redirects to sign_up path' do
+        expect(response).to redirect_to new_user_registration_path
+      end
     end
   end
 end

--- a/spec/controllers/omniauth_callbacks_controller_spec.rb
+++ b/spec/controllers/omniauth_callbacks_controller_spec.rb
@@ -31,11 +31,17 @@ RSpec.describe OmniauthCallbacksController, type: :controller do
       it 'assigns user to @user' do
         expect(assigns(:user)).to eq user
       end
-      it { should be_user_signed_in }
+      it 'redirects to sign_up path' do
+        expect(response).to redirect_to new_user_registration_path
+      end
+      it 'builds user data for resending confirmation' do
+        expect(session['devise.user'][:user_id]).to eq user.id
+      end
+      it { should_not be_user_signed_in }
     end
 
-    context 'found user with authorization' do
-      let(:auth){ create(:authorization, user: user) }
+    context 'found user with confirmed authorization' do
+      let(:auth){ create(:authorization, user: user, confirmed: true) }
       before do
         request.env["omniauth.auth"] = OmniAuth::AuthHash.new({provider: auth.provider,
                                                                uid: auth.uid,
@@ -47,6 +53,24 @@ RSpec.describe OmniauthCallbacksController, type: :controller do
         expect(assigns(:user)).to eq user
       end
       it { should be_user_signed_in }
+    end
+
+    context 'found user with unconfirmed authorization' do
+      let(:auth){ create(:authorization, user: user, confirmed: false) }
+      before do
+        request.env["omniauth.auth"] = OmniAuth::AuthHash.new({provider: auth.provider,
+                                                               uid: auth.uid,
+                                                               info: {email: user.email}})
+        get :facebook
+      end
+
+      it 'assigns user to @user' do
+        expect(assigns(:user)).to eq user
+      end
+      it 'redirects to sign_up path' do
+        expect(response).to redirect_to new_user_registration_path
+      end
+      it { should_not be_user_signed_in }
     end
   end
 
@@ -78,11 +102,17 @@ RSpec.describe OmniauthCallbacksController, type: :controller do
       it 'assigns user to @user' do
         expect(assigns(:user)).to eq user
       end
-      it { should be_user_signed_in }
+      it 'redirects to sign_up path' do
+        expect(response).to redirect_to new_user_registration_path
+      end
+      it 'builds user data for resending confirmation' do
+        expect(session['devise.user'][:user_id]).to eq user.id
+      end
+      it { should_not be_user_signed_in }
     end
 
-    context 'found user with authorization' do
-      let(:auth){ create(:authorization, provider: 'vkontakte', user: user) }
+    context 'found user with confirmed authorization' do
+      let(:auth){ create(:authorization, provider: 'vkontakte', user: user, confirmed: true) }
       before do
         request.env["omniauth.auth"] = OmniAuth::AuthHash.new({provider: auth.provider,
                                                                uid: auth.uid,
@@ -94,6 +124,24 @@ RSpec.describe OmniauthCallbacksController, type: :controller do
         expect(assigns(:user)).to eq user
       end
       it { should be_user_signed_in }
+    end
+
+    context 'found user with unconfirmed authorization' do
+      let(:auth){ create(:authorization, provider: 'vkontakte', user: user, confirmed: false) }
+      before do
+        request.env["omniauth.auth"] = OmniAuth::AuthHash.new({provider: auth.provider,
+                                                               uid: auth.uid,
+                                                               info: {email: user.email}})
+        get :vkontakte
+      end
+
+      it 'assigns user to @user' do
+        expect(assigns(:user)).to eq user
+      end
+      it 'redirects to sign_up path' do
+        expect(response).to redirect_to new_user_registration_path
+      end
+      it { should_not be_user_signed_in }
     end
   end
 
@@ -141,11 +189,14 @@ RSpec.describe OmniauthCallbacksController, type: :controller do
       it 'assigns user to @user' do
         expect(assigns(:user)).to eq user
       end
-      it { should be_user_signed_in }
+      it 'redirects to sign_up path' do
+        expect(response).to redirect_to new_user_registration_path
+      end
+      it { should_not be_user_signed_in }
     end
 
-    context 'found user with authorization' do
-      let(:auth){ create(:authorization, provider: 'twitter', user: user) }
+    context 'found user with confirmed authorization' do
+      let(:auth){ create(:authorization, provider: 'twitter', user: user, confirmed: true) }
       before do
         request.env["omniauth.auth"] = OmniAuth::AuthHash.new({provider: auth.provider,
                                                                uid: auth.uid,
@@ -157,6 +208,24 @@ RSpec.describe OmniauthCallbacksController, type: :controller do
         expect(assigns(:user)).to eq user
       end
       it { should be_user_signed_in }
+    end
+
+    context 'found user with unconfirmed authorization' do
+      let(:auth){ create(:authorization, provider: 'twitter', user: user, confirmed: false) }
+      before do
+        request.env["omniauth.auth"] = OmniAuth::AuthHash.new({provider: auth.provider,
+                                                               uid: auth.uid,
+                                                               info: {email: user.email}})
+        get :twitter
+      end
+
+      it 'assigns user to @user' do
+        expect(assigns(:user)).to eq user
+      end
+      it 'redirects to sign_up path' do
+        expect(response).to redirect_to new_user_registration_path
+      end
+      it { should_not be_user_signed_in }
     end
   end
 end

--- a/spec/models/authorization_spec.rb
+++ b/spec/models/authorization_spec.rb
@@ -4,4 +4,14 @@ RSpec.describe Authorization, type: :model do
   it { should belong_to(:user) }
   it { should validate_presence_of :provider }
   it { should validate_presence_of :uid }
+
+  describe 'confirm! method' do
+    let(:auth){ create(:authorization, token: 'mysecrettocen') }
+
+    it 'should confirm authorization' do
+      expect(auth.confirmed).to be false
+
+      expect{ auth.confirm! }.to change { auth.confirmed }.from(false).to(true)
+    end
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe User, type: :model do
       end
     end
 
-    context 'user haz no authorization' do
+    context 'user has no authorization' do
       context 'user exist' do
         let(:auth){ OmniAuth::AuthHash.new(provider: 'facebook', uid: '123456', info: {email: user.email}) }
         it 'does not create new user' do
@@ -55,6 +55,11 @@ RSpec.describe User, type: :model do
 
           expect(authorization.provider).to eq auth.provider
           expect(authorization.uid).to eq auth.uid
+          expect(authorization.confirmed).to eq false
+        end
+
+        it 'sends confirmation email' do
+          #####
         end
 
         it 'should return user' do
@@ -88,6 +93,7 @@ RSpec.describe User, type: :model do
 
           expect(authorization.provider).to eq auth.provider
           expect(authorization.uid).to eq auth.uid
+          expect(authorization.confirmed).to eq true
         end
       end
     end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -6,6 +6,7 @@ abort("The Rails environment is running in production mode!") if Rails.env.produ
 require 'spec_helper'
 require 'rspec/rails'
 require 'cancan/matchers'
+require 'capybara/email/rspec'
 # Add additional requires below this line. Rails is not loaded until this point!
 
 # Requires supporting ruby files with custom matchers and macros, etc, in


### PR DESCRIPTION
Добавил email подтверждение только в том случае, если аккаунт соцсети объединяется с существующим, мне показалось что так логичнее.
